### PR TITLE
Enforce trailing newline

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -28,4 +28,5 @@
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
     <rule ref="Generic.Formatting.SpaceAfterCast" />
+    <rule ref="PSR2.Files.EndFileNewline" />
 </ruleset>


### PR DESCRIPTION
Fixes #8 

```
> phpcs -n --ignore=vendor --extensions=php .

FILE: W:\keboola\http-extractor\src\Config.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 20 | ERROR | [x] Expected 1 newline at end of file; 0 found
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```