### PR TITLE
Enforce maximum line length 120

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -29,4 +29,9 @@
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
     <rule ref="Generic.Formatting.SpaceAfterCast" />
     <rule ref="PSR2.Files.EndFileNewline" />
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="absoluteLineLimit" value="120"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
Fixes #6 

```
FILE: W:\keboola\http-extractor\tests\functional\run.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 37 | ERROR | Line exceeds maximum limit of 120 characters; contains
    |       | 162 characters
----------------------------------------------------------------------
```