### PR TITLE
Check for dummy comments and fail when one is found

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -34,4 +34,18 @@
             <property name="absoluteLineLimit" value="120"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
+        <properties>
+            <property name="forbiddenCommentPatterns" type="array" value="
+				~^(.*)Constructor(.*)$~,
+				~^(.*)Created by PhpStorm.(.*)$~,
+				~^(.*)Created by JetBrains PhpStorm(.*)$~,
+				~^(.*)Created by (.*)@keboola\.com(.*)$~,
+				~^(.*)Date: (.*)$~,
+				~^(.*)Time: (.*)$~,
+				~^(.*)User: (.*)$~,
+				~^(.*)To change this template use File \| Settings \| File Templates.(.*)$~
+			"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
Fixes #7

```
FILE: W:\keboola\http-extractor\src\Config.php
----------------------------------------------------------------------
FOUND 5 ERRORS AFFECTING 5 LINES
----------------------------------------------------------------------
  3 | ERROR | [x] Documentation comment contains forbidden comment "-
    |       |     * Created by Miroslav Čillík <miro@keboola.com>".
  4 | ERROR | [x] Documentation comment contains forbidden comment "-
    |       |     * Date: 12/10/15".
  5 | ERROR | [x] Documentation comment contains forbidden comment "-
    |       |     * Time: 12:45".
  8 | ERROR | [x] Expected 2 newlines between PHP open tag and
    |       |     declare statement, found 1.
 18 | ERROR | [ ] Line exceeds maximum limit of 120 characters;
    |       |     contains 121 characters
----------------------------------------------------------------------
PHPCBF CAN FIX THE 4 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------


FILE: W:\keboola\http-extractor\src\HttpExtractor.php
----------------------------------------------------------------------
FOUND 7 ERRORS AFFECTING 7 LINES
----------------------------------------------------------------------
  3 | ERROR | [x] Documentation comment contains forbidden comment
    |       |     "Created by PhpStorm.".
  4 | ERROR | [x] Documentation comment contains forbidden comment
    |       |     "User: martinhalamicek".
  5 | ERROR | [x] Documentation comment contains forbidden comment
    |       |     "Date: 10/11/16".
  6 | ERROR | [x] Documentation comment contains forbidden comment
    |       |     "Time: 10:25".
  9 | ERROR | [x] Expected 2 newlines between PHP open tag and
    |       |     declare statement, found 1.
 41 | ERROR | [x] A cast statement must be followed by a single space
 59 | ERROR | [x] A cast statement must be followed by a single space
----------------------------------------------------------------------
PHPCBF CAN FIX THE 7 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```