### PR TITLE
Add DisallowYodaComparison

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -51,6 +51,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>


### PR DESCRIPTION
Add `SlevomatCodingStandard.ControlStructures.DisallowYodaComparison`


- článek o Yodovi: https://knowthecode.io/yoda-conditions-yoda-not-yoda
- symfony standards: https://symfony.com/doc/current/contributing/code/standards.html#structure
tldr; > Use Yoda conditions when checking a variable against an expression to avoid an accidental assignment inside the condition statement (this applies to ==, !=, ===, and !==);
už máme v CS `SlevomatCodingStandard.ControlStructures.AssignmentInCondition` takže assignment in condition nehrozí.

Pool: https://keboola.slack.com/archives/C9FEAHW7N/p1571166269014800