### PR TITLE
Enforce use when using namespaces

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -61,6 +61,7 @@
     </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false" />

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -61,6 +61,17 @@
     </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="allowFullyQualifiedExceptions" value="false"/>
+            <property name="allowFullyQualifiedGlobalClasses" value="false"/>
+            <property name="allowFullyQualifiedGlobalFunctions" value="false"/>
+            <property name="allowFullyQualifiedGlobalConstants" value="false"/>
+            <property name="allowFallbackGlobalFunctions" value="true"/>
+            <property name="allowFallbackGlobalConstants" value="true"/>
+            <property name="allowPartialUses" value="true"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -55,8 +55,8 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
         <properties>
-            <property name="caseSensitive" value="true"/>
-            <property name="psr12Compatible" value="false"/>
+            <property name="caseSensitive" value="false"/>
+            <property name="psr12Compatible" value="true"/>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -60,6 +60,7 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false" />

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -53,6 +53,12 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
+        <properties>
+            <property name="caseSensitive" value="true"/>
+            <property name="psr12Compatible" value="false"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false" />

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -59,6 +59,7 @@
             <property name="psr12Compatible" value="false"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false" />

--- a/test.php
+++ b/test.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+test using:
+docker run -it -v %CD%:/data php:7.4 bash
+vendor/bin/phpcs --standard=src/ruleset.xml test.php
+
+*/
+namespace X {
+
+    use InvalidArgumentException;
+    use Y\U\W;
+
+    class X
+    {
+        public function __construct()
+        {
+            $x = new InvalidArgumentException();
+            $y = new \LogicException(\PHP_VERSION);
+            echo \sprintf('%s', '1');
+            echo sprintf('%s', '1');
+            $date = new \DateTimeImmutable();
+            $obj = new \Ns\MySecondClass();
+            $obj2 = new W\TestClass();
+            throw new \Exception();
+        }
+    }
+
+    class Y
+    {
+        public function __construct()
+        {
+            $x = new X();
+        }
+    }
+}
+
+namespace Y\U\W {
+    class TestClass
+    {
+    }
+}


### PR DESCRIPTION
Test file results in:

```
 15 | ERROR | [x] Class \LogicException should not be referenced via a fully qualified name, but via a use statement.
 15 | ERROR | [x] Constant \PHP_VERSION should not be referenced via a fully qualified name, but via a use statement.
 16 | ERROR | [x] Function \sprintf() should not be referenced via a fully qualified name, but via a use statement.
 17 | ERROR | [x] Class \DateTimeImmutable should not be referenced via a fully qualified name, but via a use statement.
 18 | ERROR | [x] Class \Ns\MySecondClass should not be referenced via a fully qualified name, but via a use statement.
 20 | ERROR | [x] Class \Exception should not be referenced via a fully qualified name, but via a use statement.

```