### PR TITLE
Add easy coding standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /composer.lock
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-cli
+FROM php:8.1-cli
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * minor versions may only update underlying coding standards with bugfixes
 * major versions may introduce new sniffs, thus causing previously good builds to fail
 
-So you should be usually fine with composer's default `^major.minor`
+So you should usually be fine with composer's default `^major.minor`
 
 ## Installation
 
@@ -21,20 +21,33 @@ composer require --dev keboola/coding-standard
 vendor/bin/phpcs src tests
 ```
 
-* add phpcs script to composer.json
+* create `ecs.php` in your project root directory with the following content:
+```php
+<?php
+
+return ECSConfig::configure()->withSets([
+    __DIR__ . 'vendor/keboola/coding-standard/src/ruleset.php',
+]);
+```
+
+* command `vendor/bin/ecs src/` will now run the checks
+* command `vendor/bin/ecs --fix src/` will now run the checks with automatic fixes
+
+* add phpcs & ecs script to composer.json
 
 ```
 {
 ...
     "scripts": {
-        "phpcs": "phpcs -n --extensions=php ."
+        "phpcs": "phpcs -n --extensions=php .",
+        "ecs": "ecs"
     }
 }
 ```
 
 ## Usage
 
-`composer phpcs`
+`composer phpcs OR composer ecs`
 
 ### Using standard on legacy projects
 

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,15 @@
     "type": "phpcodesniffer-standard",
     "require": {
         "slevomat/coding-standard": "^8",
-        "squizlabs/php_codesniffer": "^3.2"
+        "squizlabs/php_codesniffer": "^3.2",
+        "symplify/easy-coding-standard": "^12.5"
     },
     "scripts": {
         "ci": [
             "@composer validate --no-check-all --strict",
             "xmllint -schema /tmp/phpcs.xsd src/ruleset.xml --noout",
-            "phpcs  --standard=src/ruleset.xml -e"
+            "phpcs  --standard=src/ruleset.xml -e",
+            "ecs"
         ]
     },
     "config": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   dev:
     build: .

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return ECSConfig::configure()->withSets([
+    __DIR__ . '/src/ruleset.php',
+]);

--- a/src/ruleset.php
+++ b/src/ruleset.php
@@ -1,0 +1,12 @@
+<?php
+
+use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use SlevomatCodingStandard\Sniffs\ControlStructures\EarlyExitSniff;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return ECSConfig::configure()
+    ->withConfiguredRule(ArraySyntaxFixer::class, ['syntax' => 'short'])
+    ->withRules([
+        EarlyExitSniff::class
+    ])
+    ->withPreparedSets(namespaces: true);

--- a/test.php
+++ b/test.php
@@ -8,6 +8,7 @@ docker run -it -v %CD%:/data php:7.4 bash
 vendor/bin/phpcs --standard=src/ruleset.xml test.php
 
 */
+
 namespace X {
 
     use InvalidArgumentException;


### PR DESCRIPTION
Pridanie ECS pre rozsirenie moznosti nasho package. ECS ma moznost spustat sniffy a fixery vramci jedneho toolu. Taktiez pridava vlastne tool sety, ktore je mozne aplikovat ako celok (namiesto jednotlivych rules)

https://github.com/easy-coding-standard/easy-coding-standard?tab=readme-ov-file#configure

V dalsich iteraciach by som chcel sa postupne zbavit XML config suboru a pouzivat iba PHP config.

S tymto PR pridavame rovno nove rules
- short syntax array
- remove unused namespaces
- early exit fixer